### PR TITLE
Use nyc to create cobertura CodeCoverage Reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "serve-debug": "node -r ts-node/register --inspect src/index.ts",
     "ci-build": "npx tsc",
     "ci-package": "mkdir -p deployment/ && npm prune --production && cp -r node_modules dist package.json index.html deployment/",
-    "ci-backend-unit-test": "mocha -r ts-node/register test/unit-tests/*.spec.ts --reporter mocha-junit-reporter --reporter-options mochaFile=./s4hana_pipeline/reports/backend-unit/results.xml",
-    "ci-integration-test": "mocha -r ts-node/register test/integration-tests/*.spec.ts --reporter mocha-junit-reporter --reporter-options mochaFile=./s4hana_pipeline/reports/integration/results.xml"
+    "ci-backend-unit-test": "nyc --extension .ts --report-dir ./s4hana_pipeline/reports/coverage-reports/ --reporter cobertura mocha -r ts-node/register test/unit-tests/*.spec.ts --reporter mocha-junit-reporter --reporter-options mochaFile=./s4hana_pipeline/reports/backend-unit/results.xml",
+    "ci-integration-test": "nyc --extension .ts --report-dir ./s4hana_pipeline/reports/coverage-reports/ --reporter cobertura mocha -r ts-node/register test/integration-tests/*.spec.ts --reporter mocha-junit-reporter --reporter-options mochaFile=./s4hana_pipeline/reports/integration/results.xml"
   },
   "author": "",
   "license": "ISC",
@@ -30,6 +30,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "node-mocks-http": "^1.7.3",
     "nodemon": "^1.18.10",
+    "nyc": "^13.3.0",
     "sinon": "^7.2.7",
     "sinon-chai": "^3.3.0",
     "ts-node": "^8.0.3",


### PR DESCRIPTION
Use nyc to create cobertura CodeCoverage Reports.
The generated report can be used in the S4SDK Pipeline.