### PR TITLE
Fix dockerImage in service-shared-config-example.yaml

### DIFF
--- a/service-shared-config-example.yaml
+++ b/service-shared-config-example.yaml
@@ -2,7 +2,7 @@ steps:
   # Should be overritten by the projects if projects only support jdk 8
   # TestCase: Test that project (book address manager) has precedence
   mavenExecute:
-    dockerImage: 'maven:3.6-jdk-11-alpine'
+    dockerImage: 'maven:3.6.3-jdk-11-slim'
 
 stages:
   # Is required by project


### PR DESCRIPTION
This change corrects the name of the dockerImage used in
service-shared-config-example.yaml, since no alpine image for jdk 11 
exists.